### PR TITLE
namedtuple uses ._asdict() in py3

### DIFF
--- a/src/Cluster_Ensembles/Cluster_Ensembles.py
+++ b/src/Cluster_Ensembles/Cluster_Ensembles.py
@@ -77,7 +77,7 @@ def memory():
 
     mem_info = dict()
 
-    for k, v in six.iteritems(psutil.virtual_memory().__dict__):
+    for k, v in psutil.virtual_memory()._asdict().items():
            mem_info[k] = int(v)
            
     return mem_info


### PR DESCRIPTION
Saw the latest merged PR, possibly indicating a commitment to py3? If so, this fixes a py2=>py3 bug (namedtuples use `._asdict()`). No hard feeling if rejected re: py2/3 cross-compatibility.