### PR TITLE
Function seems to be renamed

### DIFF
--- a/src/Cluster_Ensembles/Cluster_Ensembles.py
+++ b/src/Cluster_Ensembles/Cluster_Ensembles.py
@@ -48,7 +48,7 @@ import operator
 import pkg_resources
 import psutil
 import scipy.sparse
-from sklearn.metrics import jaccard_similarity_score
+from sklearn.metrics import jaccard_score
 from sklearn.metrics import normalized_mutual_info_score
 import subprocess
 import sys


### PR DESCRIPTION
In python3 the import fails as the jaccard seems to be renamed, see older docs of sklearn:
https://scikit-learn.org/0.17/modules/generated/sklearn.metrics.jaccard_similarity_score.html#sklearn.metrics.jaccard_similarity_score

and the stable:
https://scikit-learn.org/stable/modules/generated/sklearn.metrics.jaccard_score.html

which describe the same function, so I think its safe to rename this (and is running in my experiments).