### PR TITLE
Update jaccard score naming

### DIFF
--- a/src/Cluster_Ensembles/Cluster_Ensembles.py
+++ b/src/Cluster_Ensembles/Cluster_Ensembles.py
@@ -48,7 +48,7 @@ import operator
 import pkg_resources
 import psutil
 import scipy.sparse
-from sklearn.metrics import jaccard_similarity_score
+from sklearn.metrics import jaccard_score
 from sklearn.metrics import normalized_mutual_info_score
 import subprocess
 import sys


### PR DESCRIPTION
jaccard_similarity_score was renamed by sklearn to jaccard_score (https://scikit-learn.org/stable/modules/generated/sklearn.metrics.jaccard_score.html). Please accept the change as otherwise, the package is unusable.